### PR TITLE
load highcharts from static assets, and stop loading unused javascript

### DIFF
--- a/static/customChart.html
+++ b/static/customChart.html
@@ -32,9 +32,9 @@
     <![endif]-->
 
     <!-- Highcharts -->
-<script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/modules/exporting.js"></script>
+    <script src="/static/highcharts/highcharts.js"></script>
+    <script src="/static/highcharts/highcharts-more.js"></script>
+    <script src="/static/highcharts/modules/exporting.js"></script>
     <!--<script src="../highcharts/js/highcharts.js"></script>
     <script src="../highcharts/js/highstock.js"></script>
     <script src="../highcharts/js/modules/map.js"></script>
@@ -163,8 +163,7 @@
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="/static/assets/js/ie10-viewport-bug-workaround.js"></script>
     <script type="text/javascript" src="/static/charts.js"></script>
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.7.2.min.js"></script>
+    <!--<script type="text/javascript" src="https://code.jquery.com/jquery-1.7.2.min.js"></script>-->
     <script src="/static/Chart.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     

--- a/static/index.html
+++ b/static/index.html
@@ -32,9 +32,9 @@
     <![endif]-->
 
     <!-- Highcharts -->
-<script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/modules/exporting.js"></script>
+    <script src="/static/highcharts/highcharts.js"></script>
+    <script src="/static/highcharts/highcharts-more.js"></script>
+    <script src="/static/highcharts/modules/exporting.js"></script>
     <!--<script src="../highcharts/js/highcharts.js"></script>
     <script src="../highcharts/js/highstock.js"></script>
     <script src="../highcharts/js/modules/map.js"></script>
@@ -276,14 +276,14 @@
     <!-- Placed at the end of the document so the pages load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="/static/assets/js/vendor/jquery.min.js"><\/script>')</script>
+
     <script src="/static/dist/js/bootstrap.min.js"></script>
     <!-- Just to make our placeholder images work. Don't actually copy the next line! -->
     <script src="/static/assets/js/vendor/holder.min.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="/static/assets/js/ie10-viewport-bug-workaround.js"></script>
     <script type="text/javascript" src="/static/charts.js"></script>
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.7.2.min.js"></script>
+    <!--<script type="text/javascript" src="https://code.jquery.com/jquery-1.7.2.min.js"></script>-->
     <script src="/static/Chart.js"></script>
 
     <!-- Chart.js graphs and search and add dog -->

--- a/static/login.html
+++ b/static/login.html
@@ -69,6 +69,7 @@
     </div>
   </body>
 
+  <!-- TODO: this is a bit hacky... -->
   <script type="text/javascript">
     function checkIsRetry() {
        if (window.location.href.indexOf("?retry=true") > -1) {


### PR DESCRIPTION
this takes care of #40, additionally unused javascript is no longer loaded (google charts, older jquery).